### PR TITLE
fix: replace Prisma block comment and copy web sources before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,14 @@ Rangka kerja asas untuk Sistem Zendesk CRM berasaskan web. Projek ini mengandung
 Langkah ringkas (Debian):
 
 ```bash
-cd api
-cp .env.example .env
-pnpm install
-pnpm run format:lf
-pnpm run prisma:generate
-pnpm run prisma:migrate
-pnpm run prisma:seed
-cd ../web && pnpm install && cd ..
+cd api && cp .env.example .env && pnpm install && pnpm run format:lf && pnpm prisma:generate && pnpm prisma:migrate && pnpm prisma:seed
+cd ../web && pnpm install
 docker compose up -d --build
 ```
 
 Web: http://localhost:8080  |  API: http://localhost:8081
 
-> **Nota**: Fail Prisma mesti disimpan dalam encoding UTF-8 dengan line ending LF untuk mengelakkan ralat P1012.
+> **Nota**: Prisma hanya menyokong komen `//` atau `///` (bukan `/* ... */`). Fail Prisma mesti disimpan dalam encoding UTF-8 dengan line ending LF untuk mengelakkan ralat P1012.
 
 ## Endpoint Ringkas
 

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -67,7 +67,7 @@ enum CsatRating {
   BAD
 }
 
-/* ===================== MODELS ===================== */
+// ===================== MODELS =====================
 
 model User {
   id             String        @id @default(cuid())

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json pnpm-lock.yaml* ./
-RUN npm install -g pnpm && pnpm install && pnpm build
-CMD ["pnpm", "preview", "--host", "0.0.0.0"]
+RUN npm install -g pnpm && pnpm install
+COPY . .
+RUN pnpm build
+EXPOSE 8080
+CMD ["pnpm","preview","--host","0.0.0.0","--port","8080"]


### PR DESCRIPTION
## Summary
- fix Prisma schema comment style to avoid P1012
- rebuild web Dockerfile to copy all source before building
- document Prisma comment rules and updated build/deploy steps

## Testing
- `pnpm run format:lf`
- `pnpm build` *(api)* ❌
- `pnpm build` *(web)*

------
https://chatgpt.com/codex/tasks/task_e_68c116a3ea14832ba94a321a1aa8ee90