### PR TITLE
docs/devex: split env for docker vs host; add container-first prisma workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
-.PHONY: dev up
+.PHONY: dev db-up prisma-gen prisma-dep seed up
 
 dev:
-cd api && pnpm install && pnpm prisma:generate && cd .. \
-&& cd web && pnpm install && cd ..
+	cd api && pnpm install && pnpm prisma:generate && cd .. \
+	&& cd web && pnpm install && cd ..
+
+db-up:
+	docker compose up -d postgres redis
+
+prisma-gen:
+	docker compose run --rm api pnpm prisma:generate
+
+prisma-dep:
+	docker compose run --rm api pnpm prisma:deploy
+
+seed:
+	docker compose run --rm api pnpm prisma:seed
 
 up:
-docker compose up -d
+	docker compose up -d --build

--- a/README.md
+++ b/README.md
@@ -4,13 +4,24 @@ Rangka kerja asas untuk Sistem Zendesk CRM berasaskan web. Projek ini mengandung
 
 ## Pemasangan
 
-Langkah ringkas (Debian):
+Terdapat dua pilihan:
 
-```bash
-cd api && cp .env.example .env && pnpm install && pnpm run format:lf && pnpm prisma:generate && pnpm prisma:migrate && pnpm prisma:seed
-cd ../web && pnpm install
-docker compose up -d --build
-```
+- Dalam container:
+  ```bash
+  docker compose up -d postgres redis
+  docker compose run --rm api pnpm prisma:generate
+  docker compose run --rm api pnpm prisma:deploy
+  docker compose run --rm api pnpm prisma:seed
+  docker compose up -d --build
+  ```
+
+- Dari host (dev cepat):
+  ```bash
+  cd api && cp .env.local .env
+  pnpm prisma:generate
+  pnpm prisma:migrate
+  pnpm prisma:seed
+  ```
 
 Web: http://localhost:8080  |  API: http://localhost:8081
 

--- a/api/.env.docker
+++ b/api/.env.docker
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://appuser:apppass@postgres:5432/sistem_crm?schema=public"
+JWT_SECRET="change_me"
+REDIS_URL="redis://redis:6379"

--- a/api/.env.local
+++ b/api/.env.local
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://appuser:apppass@localhost:5432/sistem_crm?schema=public"
+JWT_SECRET="change_me"
+REDIS_URL="redis://localhost:6379"


### PR DESCRIPTION
## Summary
- add separate `.env.docker` and `.env.local` for container vs host
- document container-first prisma workflow and quick host dev setup in README
- add Makefile helpers for db/prisma commands and build

## Testing
- `pnpm prisma:generate` (fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh/... - 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c118b48794832bb5a517a53d4dda05