### PR TITLE
build(api): remove hardcoded copy of node_modules/.prisma; generate Prisma client in runtime and keep prisma CLI available

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Gunakan `.env.docker` apabila menjalankan dalam container (hostname `postgres`).
 
 ## Build API (Docker)
 
-API menggunakan Dockerfile multi-stage. Peringkat build memasang dependensi, menjalankan `pnpm prisma:generate` dan membina kod. Peringkat runtime hanya membawa masuk output build, fail Prisma dan binari Prisma daripada peringkat sebelumnya, menjadikan imej lebih kecil.
+API menggunakan Dockerfile multi-stage. Peringkat build memasang dependensi, menjalankan `pnpm prisma:generate` dan membina kod.
+
+Dengan pnpm, struktur `node_modules` berasaskan symlink; **jangan** salin `node_modules/.prisma` secara hardcoded. Peringkat runtime memasang semula dependensi (termasuk `devDependencies`), membawa masuk output build dan fail Prisma, kemudian menjana klien Prisma di dalam imej akhir.
+
+Runtime perlu memasang devDependencies supaya `pnpm prisma:deploy` dalam `entrypoint.sh` dapat dijalankan. Jika mahu membuang devDependencies, boleh gunakan `pnpm dlx prisma migrate deploy` atau pindahkan pakej `prisma` ke `dependencies`.
 
 Semasa build, `prisma generate` mesti dijalankan supaya klien Prisma tersedia. Prisma menggunakan `String` (cuid) sebagai jenis id, bukan integer; oleh itu `customerId` dalam DTO dan servis ditakrifkan sebagai `string`.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,10 +12,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 RUN npm i -g pnpm
 COPY package.json pnpm-lock.yaml* ./
-RUN pnpm install --prod
+RUN pnpm install
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/prisma ./prisma
-COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+RUN pnpm prisma:generate
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 EXPOSE 8081


### PR DESCRIPTION
## Summary
- replace runtime Docker stage to regenerate Prisma client instead of copying node_modules/.prisma and install dev deps
- document pnpm node_modules differences and need for dev deps in runtime for prisma:deploy

## Testing
- `pnpm run test` (fails: Missing script: test)
- `pnpm build` (fails: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm prisma:generate` (fails: Failed to fetch the engine file - 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c12c285e78832bb0c037d8e01f569f