### PR TITLE
fix(api): switch to Debian base and install openssl for Prisma engines; stabilize migrate deploy at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,6 @@ Dengan pnpm, struktur `node_modules` berasaskan symlink; **jangan** salin `node_
 
 Runtime perlu memasang devDependencies supaya `pnpm prisma:deploy` dalam `entrypoint.sh` dapat dijalankan. Jika mahu membuang devDependencies, boleh gunakan `pnpm dlx prisma migrate deploy` atau pindahkan pakej `prisma` ke `dependencies`.
 
+> **Nota**: Prisma memerlukan OpenSSL pada runtime; kita guna base Debian (glibc) dan pasang `openssl` untuk kestabilan. Jika mahu kekal Alpine, perlu set binary targets dan bawa masuk engine untuk musl, namun Debian adalah laluan paling stabil.
+
 Semasa build, `prisma generate` mesti dijalankan supaya klien Prisma tersedia. Prisma menggunakan `String` (cuid) sebagai jenis id, bukan integer; oleh itu `customerId` dalam DTO dan servis ditakrifkan sebagai `string`.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,15 +1,15 @@
-# ---- build stage ----
-FROM node:20-alpine AS builder
+FROM node:20-bookworm-slim AS builder
 WORKDIR /app
+RUN apt-get update && apt-get install -y openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY package.json pnpm-lock.yaml* ./
 RUN npm i -g pnpm && pnpm install
 COPY . .
 RUN pnpm prisma:generate && pnpm build
 
-# ---- runtime ----
-FROM node:20-alpine
+FROM node:20-bookworm-slim
 WORKDIR /app
 ENV NODE_ENV=production
+RUN apt-get update && apt-get install -y openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN npm i -g pnpm
 COPY package.json pnpm-lock.yaml* ./
 RUN pnpm install


### PR DESCRIPTION
## Summary
- use Debian `node:20-bookworm-slim` base image and install `openssl`/`ca-certificates` for Prisma engines
- document OpenSSL requirement and rationale for Debian base in README

## Testing
- `pnpm run test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c13232d150832b85cbaf098f18d6af